### PR TITLE
Robert Salzwedel added as endorser

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,7 +211,7 @@
 
         <p> Ryan Sweke, Marcel Goihl, Johannes Jakob Meyer, Augustine
         Kshetrimayum, Frederik Wilde, Frederik Hahn, Nathan Walk, 
-        Henrik Wilming, Paul Boes, Carlo Sparaciari and You?</p>
+        Henrik Wilming, Paul Boes, Carlo Sparaciari, Robert Salzwedel and You?</p>
         
         <h6>Cite as</h6>
 


### PR DESCRIPTION
Robert Salzwedel endorsed the Scientific conduct in his master thesis and would like to be added as endorser. 